### PR TITLE
Add documentation links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # BroadWorks-Dashboards-and-Discovery
 
 This repository holds the installation packages for the BroadWorks Dashboards and Discovery toolset.
+
+# Documentation
+
+* [Installation](BroadWorks%20Dashboards%20and%20Discovery.pdf)
+* [Dashboard Installation](BroadWorks%20Dashboard%20and%20Discovery%20-%20Dashboard%20Installation.pdf)
+* [Dashboard Plugins](BroadWorks%20Dashboard%20and%20Discovery%20Kibana%20Plugins.pdf)


### PR DESCRIPTION
The GitHub UI truncates the project documentation PDF file names, making them hard to identify.
This change adds links to the RM.